### PR TITLE
fix initial api call, add try catch for no search

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,27 +4,30 @@ import CurrentMonster from "./Components/CurrentMonster";
 import "./App.css";
 
 function App() {
+  let allMonsters = fetch(`https://www.dnd5eapi.co/api/monsters`).then((res) =>
+    res.json().then((res) => (allMonsters = res))
+  );
+
   const [monster, updateMonster] = useState("");
   const [monsterList, updateMonsterList] = useState();
   const [monsterSearch, updateMonsterSearch] = useState();
 
   const fetchMonster = () => {
-    fetch(`https://www.dnd5eapi.co/api/monsters`)
-      .then((res) => res.json())
-      .then((res) => {
-        const results = findMonster(res.results, monsterSearch);
-
-        if (results.length === 1) {
-          fetch(`https://www.dnd5eapi.co${results[0].url}`)
-            .then((res) => res.json())
-            .then((res) => {
-              updateMonster(res);
-            });
-        } else {
-          updateMonster(results);
-        }
-      })
-      .catch((e) => console.log("No monster found ", e));
+    const results = findMonster(allMonsters.results, monsterSearch);
+    try {
+      if (results.length === 1) {
+        fetch(`https://www.dnd5eapi.co${results[0].url}`)
+          .then((res) => res.json())
+          .then((res) => {
+            updateMonster(res);
+          })
+          .catch((e) => console.log("No monster found ", e));
+      } else {
+        updateMonster(results);
+      }
+    } catch (err) {
+      console.log("Error: No search term found");
+    }
   };
 
   const expandMonster = (mon) => {
@@ -36,16 +39,14 @@ function App() {
   };
 
   const randomMonster = () => {
-    fetch(`https://www.dnd5eapi.co/api/monsters`)
+    const results =
+      allMonsters.results[
+        Math.floor(Math.random() * allMonsters.results.length)
+      ];
+    fetch(`https://www.dnd5eapi.co${results.url}`)
       .then((res) => res.json())
       .then((res) => {
-        const results =
-          res.results[Math.floor(Math.random() * res.results.length)];
-        fetch(`https://www.dnd5eapi.co${results.url}`)
-          .then((res) => res.json())
-          .then((res) => {
-            updateMonster(res);
-          });
+        updateMonster(res);
       })
       .catch((e) => console.log("No monster found ", e));
   };
@@ -90,15 +91,20 @@ function App() {
           name="monsearch"
           onChange={(e) => {
             updateMonsterSearch(e.target.value);
-            if (!e.target.value){
+            if (!e.target.value) {
               updateMonster("");
               updateMonsterList("");
-            }}}
+            }
+          }}
         ></input>
         <Button wording="Search" func={fetchMonster} />
         <Button wording="Random" func={randomMonster} />
       </form>
-      <CurrentMonster monster={monster} onExpand={handleExpand} onReturn={handleReturn} />
+      <CurrentMonster
+        monster={monster}
+        onExpand={handleExpand}
+        onReturn={handleReturn}
+      />
     </div>
   );
 }

--- a/src/Components/CurrentMonster.jsx
+++ b/src/Components/CurrentMonster.jsx
@@ -27,7 +27,6 @@ const MonsterSingle = styled.div`
 
 const googleImageSearch = (monsterName) => {
   let query = monsterName.replace(" ", "+");
-  console.log(query);
   return `https://www.google.com/search?tbm=isch&q=DnD+${query}`;
 };
 


### PR DESCRIPTION
Added a seperate variable which stores the response from the initial API call, as there is no need for any additional calls once the list has been retrieved. This ensures that all further requests to the API are only for the specific search terms entered, or for the random monster button.