### PR TITLE
fix random btn bug

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -70,6 +70,7 @@ function App() {
         Math.floor(Math.random() * allMonsters.results.length)
       ];
     expandMonster(results);
+    updateMonsterList("");
   };
 
   const findMonster = (result, monsterSearch) => {


### PR DESCRIPTION
Would crash if random button was clicked first and then the monster was closed. Updated so that the random btn updates the monsterList to nothing to prevent this.